### PR TITLE
DEVOPS-354: Use v1 of Firely Azure templates

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -8,6 +8,7 @@ resources:
       type: github
       name: FirelyTeam/azure-pipeline-templates
       endpoint: FirelyTeam 
+      ref: refs/tags/v1
 
 variables:
   buildConfiguration: 'Release'


### PR DESCRIPTION
Use version `v1` (base version) of the Firely Azure templates (FirelyTeam/azure-pipeline-templates).